### PR TITLE
fix speed hack

### DIFF
--- a/Class/Hack.hpp
+++ b/Class/Hack.hpp
@@ -196,9 +196,11 @@ public:
                 Offsets::LocalPlayer::Class::ptr_staticFields,
                 Offsets::LocalPlayer::Class::StaticField::f_movementSpeed
             };
-            int64_t movementSpeed_addr = memory.FindPointer(localPlayer->address, offsets);
+            ObscuredFloat *movementSpeed_addr = (ObscuredFloat*)memory.FindPointer(localPlayer->address, offsets);
 
-            memory.write_mem<float>(movementSpeed_addr, targetSpeed);
+            memory.write_mem<bool>((int64_t)&movementSpeed_addr->fakeValueActive, false);
+            memory.write_mem<float>((int64_t)movementSpeed_addr, targetSpeed);
+            memory.write_mem<int32_t>((int64_t)movementSpeed_addr + 4, 0);
 
             //更新GUI显示的设置速度
             hackSettings.guiSettings.f_movementSpeed = targetSpeed;

--- a/Memory.h
+++ b/Memory.h
@@ -63,7 +63,7 @@ public:
         if (hackSettings.b_debug_disableWriteMemory) {
             return false;
         }
-        int bytesWrote = 0;
+        SIZE_T bytesWrote = 0;
         WriteProcessMemory(processHandle, (LPVOID)address, &value, sizeof(var), &bytesWrote);
         return bytesWrote != 0;
     }
@@ -91,7 +91,7 @@ public:
         if (!this->isAddressInMemoryRegions(address)) {
             return false;
         }
-        int bytesRead = 0;
+        SIZE_T bytesRead = 0;
         ReadProcessMemory(processHandle, (LPCVOID)address, &value, sizeof(var), &bytesRead);
 
         return bytesRead != 0;

--- a/UI/Drawing.cpp
+++ b/UI/Drawing.cpp
@@ -698,8 +698,6 @@ void drawMenu() {
 
             ImGui::Checkbox(str("Remove skill cooldown", "移除技能冷却时间"), &hackSettings.b_removeSkillCoolDown);
 
-            //TODO: 移速被加密
-            ImGui::BeginDisabled();
             ImGui::Checkbox(str("Enable##speedHack", "启用##speedHack"), &hackSettings.guiSettings.b_enableSpeedHack);
             ImGui::SameLine();
             ImGui::SliderFloat(
@@ -708,7 +706,6 @@ void drawMenu() {
                 minSpeed,
                 minSpeed * 2
             );
-            ImGui::EndDisabled();
 
             ImGui::Checkbox(str("Enable##zoomHack", "启用##zoomHack"), &hackSettings.guiSettings.b_enableZoomHack);
             ImGui::SameLine();


### PR DESCRIPTION
ObscuredFloat 的一种解决方案：

1. 禁用掉 fakeValue
2. 将实际值写到 currentCryptoKey 字段
3. hiddenValue 字段置零

hiddenValue 在解密时会先进行 UnShuffle 操作改变一些字节的顺序，之后再与 currentCryptoKey 异或得到明文值，所以直接把值写到 currentCryptoKey 是相对简单的方式。其他的 ObscuredType 应该也可以暂时用这种方式解决。